### PR TITLE
channel names included in default header

### DIFF
--- a/subsystems/hexe_edm/data/master_control.json
+++ b/subsystems/hexe_edm/data/master_control.json
@@ -7,7 +7,19 @@
   "default_header_info" : {
   				"full_scale": 20,
   				"conversion_factor": 0.985e-9,
-  				"external_clock": True
+  				"external_clock": True,
+  				"channel_names" : {
+				"0" : "SQUID_X1",
+    				"1" : "SQUID_Y1",
+    				"2" : "SQUID_Z1",
+    				"3" : "SQUID_X2",
+    				"4" : "SQUID_Y2",
+    				"5" : "SQUID_Z2",
+    				"6" : "Lockin_XE",
+    				"7" : "Lockin_HE",
+    				"8" : "CH8",
+    				"9" : "CH9"
+  				}
   },
   "channel_names" : {
     "0" : "SQUID_X1",


### PR DESCRIPTION
I included a list of channel names in the default header field. maybe it should be included in the digitizer template to always save the channel names to the header